### PR TITLE
Adds base visitors

### DIFF
--- a/packages/MusicNotation-Core.package/MNBlockVisitor.class/class/newWith..st
+++ b/packages/MusicNotation-Core.package/MNBlockVisitor.class/class/newWith..st
@@ -1,0 +1,5 @@
+instance creation
+newWith: aBlock
+	^ self new
+		block: aBlock;
+		yourself

--- a/packages/MusicNotation-Core.package/MNBlockVisitor.class/instance/block..st
+++ b/packages/MusicNotation-Core.package/MNBlockVisitor.class/instance/block..st
@@ -1,0 +1,3 @@
+accessing
+block: anObject
+	block := anObject

--- a/packages/MusicNotation-Core.package/MNBlockVisitor.class/instance/block.st
+++ b/packages/MusicNotation-Core.package/MNBlockVisitor.class/instance/block.st
@@ -1,0 +1,3 @@
+accessing
+block
+	^ block

--- a/packages/MusicNotation-Core.package/MNBlockVisitor.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNBlockVisitor.class/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		"newWith:" : "mgjm 5/16/2019 02:46" },
+	"instance" : {
+		"block" : "mgjm 5/16/2019 02:43",
+		"block:" : "mgjm 5/16/2019 02:43" } }

--- a/packages/MusicNotation-Core.package/MNBlockVisitor.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNBlockVisitor.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		"block" ],
+	"name" : "MNBlockVisitor",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "MNMusicVisitor",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNFlatTransposer.class/instance/alterFor..st
+++ b/packages/MusicNotation-Core.package/MNFlatTransposer.class/instance/alterFor..st
@@ -1,0 +1,3 @@
+accessing
+alterFor: anInteger
+	^ (self alterByHalfStep at: anInteger) negated

--- a/packages/MusicNotation-Core.package/MNFlatTransposer.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNFlatTransposer.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"alterFor:" : "mgjm 5/16/2019 01:41" } }

--- a/packages/MusicNotation-Core.package/MNFlatTransposer.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNFlatTransposer.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		 ],
+	"name" : "MNFlatTransposer",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "MNTransposer",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNMeasure.class/instance/accept..st
+++ b/packages/MusicNotation-Core.package/MNMeasure.class/instance/accept..st
@@ -1,0 +1,3 @@
+visiting
+accept: aVisitor
+	^ aVisitor visitMeasure: self

--- a/packages/MusicNotation-Core.package/MNMeasure.class/instance/notesAccept..st
+++ b/packages/MusicNotation-Core.package/MNMeasure.class/instance/notesAccept..st
@@ -1,0 +1,3 @@
+visiting
+notesAccept: aVisitor
+	self notes do: [ :each | each notesAccept: aVisitor ].

--- a/packages/MusicNotation-Core.package/MNMeasure.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNMeasure.class/methodProperties.json
@@ -2,7 +2,9 @@
 	"class" : {
 		 },
 	"instance" : {
+		"accept:" : "mgjm 5/15/2019 20:38",
 		"addNote:" : "mgjm 4/18/2019 14:58",
 		"initialize" : "mgjm 4/18/2019 14:58",
 		"notes" : "mgjm 4/18/2019 14:57",
-		"notes:" : "mgjm 4/18/2019 14:57" } }
+		"notes:" : "mgjm 4/18/2019 14:57",
+		"notesAccept:" : "mgjm 5/15/2019 20:44" } }

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/accept..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/accept..st
@@ -1,0 +1,3 @@
+visiting
+accept: aVisitor
+	self subclassResponsibility.

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/asSound.st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/asSound.st
@@ -1,0 +1,6 @@
+converting
+asSound
+	| soundGenerator |
+	soundGenerator := MNSoundGenerator2 new.
+	self accept: soundGenerator.
+	^ soundGenerator soundSequence

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/notesAccept..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/notesAccept..st
@@ -1,0 +1,3 @@
+visiting
+notesAccept: aVisitor
+	self subclassResponsibility.

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/notesDo..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/notesDo..st
@@ -1,0 +1,3 @@
+enumerating
+notesDo: aBlock
+	self accept: (MNNoteVisitor newWith: aBlock).

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/pitchesDo..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/pitchesDo..st
@@ -1,0 +1,3 @@
+enumerating
+pitchesDo: aBlock
+	self accept: (MNPitchVisitor newWith: aBlock).

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transpose..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transpose..st
@@ -1,0 +1,3 @@
+as yet unclassified
+transpose: halfSteps
+	self transposeSharp: halfSteps.

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transpose.withClass..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transpose.withClass..st
@@ -1,0 +1,6 @@
+as yet unclassified
+transpose: halfSteps withClass: aTransposerClass
+	| transpose |
+	transpose := aTransposerClass new.
+	transpose offset: halfSteps.
+	self pitchesDo: transpose.

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transposeFlat..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transposeFlat..st
@@ -1,0 +1,3 @@
+as yet unclassified
+transposeFlat: halfSteps
+	self transpose: halfSteps withClass: MNFlatTransposer.

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transposeSharp..st
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/instance/transposeSharp..st
@@ -1,0 +1,3 @@
+as yet unclassified
+transposeSharp: halfSteps
+	self transpose: halfSteps withClass: MNSharpTransposer.

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/methodProperties.json
@@ -1,0 +1,13 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"accept:" : "mgjm 5/15/2019 20:25",
+		"asSound" : "mgjm 5/15/2019 20:30",
+		"notesAccept:" : "mgjm 5/15/2019 20:28",
+		"notesDo:" : "mgjm 5/16/2019 02:57",
+		"pitchesDo:" : "mgjm 5/16/2019 02:46",
+		"transpose:" : "mgjm 5/16/2019 01:52",
+		"transpose:withClass:" : "mgjm 5/16/2019 02:53",
+		"transposeFlat:" : "mgjm 5/16/2019 01:52",
+		"transposeSharp:" : "mgjm 5/16/2019 01:52" } }

--- a/packages/MusicNotation-Core.package/MNMusicObject.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNMusicObject.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		 ],
+	"name" : "MNMusicObject",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "Object",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitMeasure..st
+++ b/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitMeasure..st
@@ -1,0 +1,3 @@
+visiting
+visitMeasure: aMeasure
+	^ aMeasure notesAccept: self.

--- a/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitNote..st
+++ b/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitNote..st
@@ -1,0 +1,3 @@
+visiting
+visitNote: aNote
+	self subclassResponsibility.

--- a/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitPart..st
+++ b/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitPart..st
@@ -1,0 +1,3 @@
+visiting
+visitPart: aPart
+	^ aPart notesAccept: self.

--- a/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitProject..st
+++ b/packages/MusicNotation-Core.package/MNMusicVisitor.class/instance/visitProject..st
@@ -1,0 +1,3 @@
+visiting
+visitProject: aProject
+	^ aProject notesAccept: self.

--- a/packages/MusicNotation-Core.package/MNMusicVisitor.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNMusicVisitor.class/methodProperties.json
@@ -1,0 +1,8 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"visitMeasure:" : "mgjm 5/15/2019 20:27",
+		"visitNote:" : "mgjm 5/15/2019 20:27",
+		"visitPart:" : "mgjm 5/15/2019 20:42",
+		"visitProject:" : "mgjm 5/15/2019 20:48" } }

--- a/packages/MusicNotation-Core.package/MNMusicVisitor.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNMusicVisitor.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		 ],
+	"name" : "MNMusicVisitor",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "Object",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNNote.class/instance/accept..st
+++ b/packages/MusicNotation-Core.package/MNNote.class/instance/accept..st
@@ -1,0 +1,3 @@
+visiting
+accept: aVisitor
+	^ aVisitor visitNote: self

--- a/packages/MusicNotation-Core.package/MNNote.class/instance/notesAccept..st
+++ b/packages/MusicNotation-Core.package/MNNote.class/instance/notesAccept..st
@@ -1,0 +1,3 @@
+visiting
+notesAccept: aVisitor
+	self accept: aVisitor.

--- a/packages/MusicNotation-Core.package/MNNote.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNNote.class/methodProperties.json
@@ -2,9 +2,11 @@
 	"class" : {
 		 },
 	"instance" : {
+		"accept:" : "mgjm 5/15/2019 20:32",
 		"addPitch:" : "mgjm 4/18/2019 16:34",
 		"duration" : "mgjm 4/18/2019 16:31",
 		"duration:" : "aw 5/6/2019 23:14",
 		"initialize" : "mgjm 4/18/2019 16:33",
+		"notesAccept:" : "mgjm 5/15/2019 20:45",
 		"pitches" : "mgjm 4/18/2019 16:32",
 		"pitches:" : "mgjm 4/18/2019 16:32" } }

--- a/packages/MusicNotation-Core.package/MNNote.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNNote.class/properties.json
@@ -11,5 +11,5 @@
 	"name" : "MNNote",
 	"pools" : [
 		 ],
-	"super" : "Object",
+	"super" : "MNMusicObject",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNNoteVisitor.class/instance/visitNote..st
+++ b/packages/MusicNotation-Core.package/MNNoteVisitor.class/instance/visitNote..st
@@ -1,0 +1,3 @@
+visiting
+visitNote: aNote
+	self block value: aNote.

--- a/packages/MusicNotation-Core.package/MNNoteVisitor.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNNoteVisitor.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"visitNote:" : "mgjm 5/16/2019 02:44" } }

--- a/packages/MusicNotation-Core.package/MNNoteVisitor.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNNoteVisitor.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		 ],
+	"name" : "MNNoteVisitor",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "MNBlockVisitor",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNPart.class/instance/accept..st
+++ b/packages/MusicNotation-Core.package/MNPart.class/instance/accept..st
@@ -1,0 +1,3 @@
+visiting
+accept: aVisitor
+	^ aVisitor visitPart: self

--- a/packages/MusicNotation-Core.package/MNPart.class/instance/notesAccept..st
+++ b/packages/MusicNotation-Core.package/MNPart.class/instance/notesAccept..st
@@ -1,0 +1,3 @@
+visiting
+notesAccept: aVisitor
+	self measures do: [ :each | each notesAccept: aVisitor ].

--- a/packages/MusicNotation-Core.package/MNPart.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNPart.class/methodProperties.json
@@ -2,7 +2,9 @@
 	"class" : {
 		 },
 	"instance" : {
+		"accept:" : "mgjm 5/15/2019 20:40",
 		"addMeasure:" : "mgjm 4/18/2019 16:27",
 		"initialize" : "mgjm 4/18/2019 16:27",
 		"measures" : "mgjm 4/18/2019 14:59",
-		"measures:" : "mgjm 4/18/2019 14:59" } }
+		"measures:" : "mgjm 4/18/2019 14:59",
+		"notesAccept:" : "mgjm 5/15/2019 20:43" } }

--- a/packages/MusicNotation-Core.package/MNPart.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNPart.class/properties.json
@@ -10,5 +10,5 @@
 	"name" : "MNPart",
 	"pools" : [
 		 ],
-	"super" : "Object",
+	"super" : "MNMusicObject",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNPitch.class/instance/alter..st
+++ b/packages/MusicNotation-Core.package/MNPitch.class/instance/alter..st
@@ -1,3 +1,5 @@
 accessing
 alter: anObject
-	alter := anObject
+	(#(-1 0 1) includes: anObject)
+		ifFalse: [ self halt: 'invalid alter: ', anObject, ' (allowed values: -1, 0, 1)' ].
+	alter := anObject.

--- a/packages/MusicNotation-Core.package/MNPitch.class/instance/octave..st
+++ b/packages/MusicNotation-Core.package/MNPitch.class/instance/octave..st
@@ -1,3 +1,3 @@
 accessing
 octave: anObject
-	octave := anObject
+	octave := anObject asInteger.

--- a/packages/MusicNotation-Core.package/MNPitch.class/instance/step..st
+++ b/packages/MusicNotation-Core.package/MNPitch.class/instance/step..st
@@ -1,3 +1,3 @@
 accessing
 step: anObject
-	step := anObject
+	step := anObject asCharacter asLowercase.

--- a/packages/MusicNotation-Core.package/MNPitch.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNPitch.class/methodProperties.json
@@ -3,7 +3,7 @@
 		"readFrom:" : "mgjm 4/18/2019 12:35" },
 	"instance" : {
 		"alter" : "mgjm 4/18/2019 12:03",
-		"alter:" : "mgjm 4/18/2019 12:03",
+		"alter:" : "mgjm 5/22/2019 18:09",
 		"alterString" : "mgjm 5/6/2019 22:12",
 		"frequency" : "mgjm 5/6/2019 22:13",
 		"initialize" : "mgjm 4/18/2019 17:18",
@@ -11,6 +11,6 @@
 		"isNormal" : "mgjm 4/18/2019 12:04",
 		"isSharp" : "mgjm 4/18/2019 12:04",
 		"octave" : "mgjm 4/18/2019 12:03",
-		"octave:" : "mgjm 4/18/2019 12:03",
+		"octave:" : "mgjm 5/22/2019 18:05",
 		"step" : "mgjm 4/18/2019 12:03",
-		"step:" : "mgjm 4/18/2019 12:03" } }
+		"step:" : "mgjm 5/22/2019 18:05" } }

--- a/packages/MusicNotation-Core.package/MNPitchVisitor.class/instance/visitNote..st
+++ b/packages/MusicNotation-Core.package/MNPitchVisitor.class/instance/visitNote..st
@@ -1,0 +1,3 @@
+visiting
+visitNote: aNote
+	aNote pitches do: self block.

--- a/packages/MusicNotation-Core.package/MNPitchVisitor.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNPitchVisitor.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"visitNote:" : "mgjm 5/16/2019 02:44" } }

--- a/packages/MusicNotation-Core.package/MNPitchVisitor.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNPitchVisitor.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		 ],
+	"name" : "MNPitchVisitor",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "MNBlockVisitor",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNProject.class/instance/accept..st
+++ b/packages/MusicNotation-Core.package/MNProject.class/instance/accept..st
@@ -1,0 +1,3 @@
+visiting
+accept: aVisitor
+	^ aVisitor visitProject: self

--- a/packages/MusicNotation-Core.package/MNProject.class/instance/notesAccept..st
+++ b/packages/MusicNotation-Core.package/MNProject.class/instance/notesAccept..st
@@ -1,0 +1,3 @@
+visiting
+notesAccept: aVisitor
+	self parts do: [ :each | each notesAccept: aVisitor ].

--- a/packages/MusicNotation-Core.package/MNProject.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNProject.class/methodProperties.json
@@ -2,7 +2,9 @@
 	"class" : {
 		 },
 	"instance" : {
+		"accept:" : "mgjm 5/15/2019 20:47",
 		"addPart:" : "mgjm 4/18/2019 16:28",
 		"initialize" : "mgjm 4/18/2019 16:28",
+		"notesAccept:" : "mgjm 5/15/2019 20:51",
 		"parts" : "mgjm 4/18/2019 16:28",
 		"parts:" : "mgjm 4/18/2019 16:28" } }

--- a/packages/MusicNotation-Core.package/MNProject.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNProject.class/properties.json
@@ -10,5 +10,5 @@
 	"name" : "MNProject",
 	"pools" : [
 		 ],
-	"super" : "Object",
+	"super" : "MNMusicObject",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNSharpTransposer.class/instance/alterFor..st
+++ b/packages/MusicNotation-Core.package/MNSharpTransposer.class/instance/alterFor..st
@@ -1,0 +1,3 @@
+accessing
+alterFor: anInteger
+	^ self alterByHalfStep at: anInteger

--- a/packages/MusicNotation-Core.package/MNSharpTransposer.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNSharpTransposer.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"alterFor:" : "mgjm 5/16/2019 01:41" } }

--- a/packages/MusicNotation-Core.package/MNSharpTransposer.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNSharpTransposer.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		 ],
+	"name" : "MNSharpTransposer",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "MNTransposer",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/addSound..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/addSound..st
@@ -1,0 +1,9 @@
+adding
+addSound: aSound
+	self soundSequence ifNil: [ ^ self soundSequence: aSound ].
+	(self soundSequence isKindOf: SequentialSound)
+		ifFalse: [ | sound |
+			sound := self soundSequence.
+			self soundSequence: SequentialSound new.
+			self soundSequence add: sound ].
+	self soundSequence add: aSound.

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/baseSound..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/baseSound..st
@@ -1,0 +1,3 @@
+accessing
+baseSound: anObject
+	baseSound := anObject

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/baseSound.st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/baseSound.st
@@ -1,0 +1,3 @@
+accessing
+baseSound
+	^ baseSound ifNil: [ self defaultBaseSound ]

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/convertDuration..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/convertDuration..st
@@ -1,0 +1,3 @@
+accessing
+convertDuration: aFraction
+	^ aFraction *  2

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/defaultBaseSound.st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/defaultBaseSound.st
@@ -1,0 +1,3 @@
+accessing
+defaultBaseSound
+	^ FMSound mellowBrass

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/generateMixedSound.collect..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/generateMixedSound.collect..st
@@ -1,0 +1,7 @@
+generating
+generateMixedSound: aCollection collect: aBlock
+	| mixedSound |
+	mixedSound := MixedSound new.
+	aCollection do: [ :each |
+		mixedSound add: (aBlock value: each) ].
+	^ mixedSound

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/generateNote..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/generateNote..st
@@ -1,0 +1,13 @@
+generating
+generateNote: aNote
+	| time |
+	time := self convertDuration: aNote duration.
+	
+	aNote pitches
+		ifEmpty: [ ^ RestSound dur: time ].
+	
+	aNote pitches size = 1
+		ifTrue: [ ^ self generatePitch: aNote pitches first duration: time ].
+	
+	^ self generateMixedSound: aNote pitches
+		collect: [ :each | self generatePitch: each duration: time ]

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/generatePitch.duration..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/generatePitch.duration..st
@@ -1,0 +1,3 @@
+generating
+generatePitch: aPitch duration: aNumber
+	^ self baseSound soundForPitch: aPitch frequency dur: aNumber loudness: self loudness

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/loudness.st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/loudness.st
@@ -1,0 +1,3 @@
+accessing
+loudness
+	^ 1

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/soundSequence..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/soundSequence..st
@@ -1,0 +1,3 @@
+accessing
+soundSequence: anObject
+	soundSequence := anObject

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/soundSequence.st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/soundSequence.st
@@ -1,0 +1,3 @@
+accessing
+soundSequence
+	^ soundSequence

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/visitNote..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/visitNote..st
@@ -1,0 +1,3 @@
+visiting
+visitNote: aNote
+	self addSound: (self generateNote: aNote).

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/visitProject..st
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/instance/visitProject..st
@@ -1,0 +1,9 @@
+visiting
+visitProject: aProject
+	aProject parts ifEmpty: [ ^ self ].
+	
+	aProject parts size = 1
+		ifTrue: [ ^ aProject parts first accept: self ].
+	
+	self addSound: (self generateMixedSound: aProject parts
+		collect: [ :each | each asSound ]).

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/methodProperties.json
@@ -1,0 +1,17 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"addSound:" : "mgjm 5/16/2019 03:14",
+		"baseSound" : "mgjm 5/16/2019 03:00",
+		"baseSound:" : "mgjm 5/16/2019 02:59",
+		"convertDuration:" : "mgjm 5/15/2019 20:36",
+		"defaultBaseSound" : "mgjm 5/16/2019 03:00",
+		"generateMixedSound:collect:" : "mgjm 5/16/2019 02:11",
+		"generateNote:" : "mgjm 5/15/2019 21:10",
+		"generatePitch:duration:" : "mgjm 5/16/2019 03:00",
+		"loudness" : "mgjm 5/15/2019 20:34",
+		"soundSequence" : "mgjm 5/16/2019 03:03",
+		"soundSequence:" : "mgjm 5/15/2019 20:33",
+		"visitNote:" : "mgjm 5/15/2019 21:05",
+		"visitProject:" : "mgjm 5/16/2019 03:01" } }

--- a/packages/MusicNotation-Core.package/MNSoundGenerator2.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNSoundGenerator2.class/properties.json
@@ -6,9 +6,10 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		"soundSequence",
+		"baseSound" ],
+	"name" : "MNSoundGenerator2",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "MNMusicVisitor",
 	"type" : "normal" }

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/alterByHalfStep.st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/alterByHalfStep.st
@@ -1,0 +1,3 @@
+accessing
+alterByHalfStep
+	^ #(0 1 0 1 0 0 1 0 1 0 1 0)

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/alterFor..st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/alterFor..st
@@ -1,0 +1,3 @@
+accessing
+alterFor: anInteger
+	self subclassResponsibility.

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/halfStepSymbols.st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/halfStepSymbols.st
@@ -1,0 +1,3 @@
+accessing
+halfStepSymbols
+	^ #c_d_ef_g_a_b

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/halfStepsInOctave.st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/halfStepsInOctave.st
@@ -1,0 +1,3 @@
+accessing
+halfStepsInOctave
+	^ self halfStepSymbols size

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/halfStepsOf..st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/halfStepsOf..st
@@ -1,0 +1,7 @@
+converting
+halfStepsOf: aPitch
+	| halfSteps |
+	halfSteps := (self halfStepSymbols indexOf: aPitch step) - 1.
+	halfSteps := halfSteps + (aPitch octave * self halfStepsInOctave).
+	halfSteps := halfSteps + aPitch alter.
+	^ halfSteps

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/offset..st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/offset..st
@@ -1,0 +1,3 @@
+accessing
+offset: anObject
+	offset := anObject

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/offset.st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/offset.st
@@ -1,0 +1,3 @@
+accessing
+offset
+	^ offset

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/setHalfSteps.of..st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/setHalfSteps.of..st
@@ -1,0 +1,11 @@
+converting
+setHalfSteps: anInteger of: aPitch
+	| alter value step |
+	value := anInteger \\ 12 + 1.
+	aPitch octave: anInteger // self halfStepsInOctave.
+	
+	alter := self alterFor: value.
+	aPitch alter: alter.
+	
+	step := self halfStepSymbols at: value - alter.
+	aPitch step: step.

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/transpose..st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/transpose..st
@@ -1,0 +1,6 @@
+converting
+transpose: aPitch
+	| value |
+	value := self halfStepsOf: aPitch.
+	value := value + self offset.
+	self setHalfSteps: value of: aPitch.

--- a/packages/MusicNotation-Core.package/MNTransposer.class/instance/value..st
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/instance/value..st
@@ -1,0 +1,5 @@
+converting
+value: aPitch
+	"Overwritten so that the transposer can be used as a block"
+	"e.g: aMusicObject pitchesDo: aTransposer"
+	self transpose: aPitch.

--- a/packages/MusicNotation-Core.package/MNTransposer.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/methodProperties.json
@@ -1,0 +1,14 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"alterByHalfStep" : "mgjm 5/16/2019 01:34",
+		"alterFor:" : "mgjm 5/16/2019 01:40",
+		"halfStepSymbols" : "mgjm 5/16/2019 02:06",
+		"halfStepsInOctave" : "mgjm 5/16/2019 01:28",
+		"halfStepsOf:" : "mgjm 5/16/2019 02:09",
+		"offset" : "mgjm 5/16/2019 02:50",
+		"offset:" : "mgjm 5/16/2019 02:50",
+		"setHalfSteps:of:" : "mgjm 5/16/2019 01:39",
+		"transpose:" : "mgjm 5/16/2019 02:52",
+		"value:" : "mgjm 5/16/2019 03:19" } }

--- a/packages/MusicNotation-Core.package/MNTransposer.class/properties.json
+++ b/packages/MusicNotation-Core.package/MNTransposer.class/properties.json
@@ -6,9 +6,9 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"notes" ],
-	"name" : "MNMeasure",
+		"offset" ],
+	"name" : "MNTransposer",
 	"pools" : [
 		 ],
-	"super" : "MNMusicObject",
+	"super" : "Object",
 	"type" : "normal" }

--- a/packages/MusicNotation-Tests.package/MNMeasureTest.class/instance/testMeasureAccept.st
+++ b/packages/MusicNotation-Tests.package/MNMeasureTest.class/instance/testMeasureAccept.st
@@ -1,0 +1,7 @@
+as yet unclassified
+testMeasureAccept
+	| measure |
+	measure := MNMeasure new.
+	self assert: (MNTestCallRecorder new
+		do: [ :v | measure accept: v ];
+		isSingleCallTo: #visitMeasure: with: measure).

--- a/packages/MusicNotation-Tests.package/MNMeasureTest.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNMeasureTest.class/methodProperties.json
@@ -3,5 +3,6 @@
 		 },
 	"instance" : {
 		"testEmptyMeasure" : "aw 5/6/2019 23:22",
+		"testMeasureAccept" : "mgjm 5/22/2019 22:41",
 		"testMeasureWithA4" : "aw 5/6/2019 23:25",
 		"testMeasureWithA4C5" : "aw 5/6/2019 23:27" } }

--- a/packages/MusicNotation-Tests.package/MNNoteTest.class/instance/testNoteAccept.st
+++ b/packages/MusicNotation-Tests.package/MNNoteTest.class/instance/testNoteAccept.st
@@ -1,0 +1,7 @@
+as yet unclassified
+testNoteAccept
+	| note |
+	note := MNNote new.
+	self assert: (MNTestCallRecorder new
+		do: [ :v | note accept: v ];
+		isSingleCallTo: #visitNote: with: note).

--- a/packages/MusicNotation-Tests.package/MNNoteTest.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNNoteTest.class/methodProperties.json
@@ -3,6 +3,7 @@
 		 },
 	"instance" : {
 		"testDurationFraction" : "aw 5/6/2019 23:14",
+		"testNoteAccept" : "mgjm 5/22/2019 22:41",
 		"testQuarterA4" : "aw 5/6/2019 23:11",
 		"testQuarterA4C5" : "aw 5/6/2019 23:11",
 		"testQuarterRest" : "aw 5/6/2019 22:51" } }

--- a/packages/MusicNotation-Tests.package/MNPartTest.class/instance/testPartAccept.st
+++ b/packages/MusicNotation-Tests.package/MNPartTest.class/instance/testPartAccept.st
@@ -1,0 +1,7 @@
+as yet unclassified
+testPartAccept
+	| part |
+	part := MNPart new.
+	self assert: (MNTestCallRecorder new
+		do: [ :v | part accept: v ];
+		isSingleCallTo: #visitPart: with: part).

--- a/packages/MusicNotation-Tests.package/MNPartTest.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNPartTest.class/methodProperties.json
@@ -3,5 +3,6 @@
 		 },
 	"instance" : {
 		"testEmptyPart" : "aw 5/6/2019 23:54",
+		"testPartAccept" : "mgjm 5/22/2019 22:41",
 		"testPartWithMeasure" : "aw 5/6/2019 23:56",
 		"testPartWithTwoMeasures" : "aw 5/7/2019 16:26" } }

--- a/packages/MusicNotation-Tests.package/MNProjectTest.class/instance/testProjectAccept.st
+++ b/packages/MusicNotation-Tests.package/MNProjectTest.class/instance/testProjectAccept.st
@@ -1,0 +1,7 @@
+as yet unclassified
+testProjectAccept
+	| project |
+	project := MNProject new.
+	self assert: (MNTestCallRecorder new
+		do: [ :v | project accept: v ];
+		isSingleCallTo: #visitProject: with: project).

--- a/packages/MusicNotation-Tests.package/MNProjectTest.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNProjectTest.class/methodProperties.json
@@ -3,5 +3,6 @@
 		 },
 	"instance" : {
 		"testEmptyProject" : "aw 5/6/2019 23:57",
+		"testProjectAccept" : "mgjm 5/22/2019 22:41",
 		"testProjectWithPart" : "aw 5/7/2019 00:01",
 		"testProjectWithTwoParts" : "aw 5/7/2019 16:28" } }

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/calls..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/calls..st
@@ -1,0 +1,3 @@
+accessing
+calls: anObject
+	calls := anObject

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/calls.st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/calls.st
@@ -1,0 +1,3 @@
+accessing
+calls
+	^ calls ifNil: [ calls := OrderedCollection new ]

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/depth..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/depth..st
@@ -1,0 +1,3 @@
+accessing
+depth: anObject
+	depth := anObject

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/depth.st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/depth.st
@@ -1,0 +1,3 @@
+accessing
+depth
+	^ depth ifNil: [ depth := 0 ]

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/do..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/do..st
@@ -1,0 +1,5 @@
+accessing
+do: aBlock
+	self depth: self depth + 1.
+	aBlock value: self.
+	self depth: self depth - 1.

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/doesNotUnderstand..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/doesNotUnderstand..st
@@ -1,0 +1,5 @@
+error handling
+doesNotUnderstand: aMessage
+	self isRecording
+		ifTrue: [ self calls add: aMessage ]
+		ifFalse: [ ^ super doesNotUnderstand: aMessage ].

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isCallTo..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isCallTo..st
@@ -1,0 +1,3 @@
+testing
+isCallTo: aSymbol
+	^ self calls removeFirst selector == aSymbol

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isCallTo.with..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isCallTo.with..st
@@ -1,0 +1,4 @@
+testing
+isCallTo: aSymbol with: aValue
+	^ self calls first arguments first == aValue
+		and: [ self isCallTo: aSymbol ].

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isDone.st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isDone.st
@@ -1,0 +1,3 @@
+testing
+isDone
+	^ self calls isEmpty

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isRecording.st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isRecording.st
@@ -1,0 +1,3 @@
+testing
+isRecording
+	^ self depth > 0

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isSingleCallTo..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isSingleCallTo..st
@@ -1,0 +1,4 @@
+testing
+isSingleCallTo: aSymbol
+	^ (self isCallTo: aSymbol)
+		and: [ self isDone ]

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isSingleCallTo.with..st
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/instance/isSingleCallTo.with..st
@@ -1,0 +1,4 @@
+testing
+isSingleCallTo: aSymbol with: aValue
+	^ (self isCallTo: aSymbol with: aValue)
+		and: [ self isDone ]

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/methodProperties.json
@@ -1,0 +1,16 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"calls" : "mgjm 5/22/2019 22:29",
+		"calls:" : "mgjm 5/22/2019 22:22",
+		"depth" : "mgjm 5/22/2019 22:24",
+		"depth:" : "mgjm 5/22/2019 22:24",
+		"do:" : "mgjm 5/22/2019 22:25",
+		"doesNotUnderstand:" : "mgjm 5/22/2019 22:26",
+		"isCallTo:" : "mgjm 5/22/2019 22:33",
+		"isCallTo:with:" : "mgjm 5/22/2019 22:39",
+		"isDone" : "mgjm 5/22/2019 22:31",
+		"isRecording" : "mgjm 5/22/2019 22:23",
+		"isSingleCallTo:" : "mgjm 5/22/2019 22:31",
+		"isSingleCallTo:with:" : "mgjm 5/22/2019 22:37" } }

--- a/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/properties.json
+++ b/packages/MusicNotation-Tests.package/MNTestCallRecorder.class/properties.json
@@ -1,0 +1,15 @@
+{
+	"category" : "MusicNotation-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"calls",
+		"depth" ],
+	"name" : "MNTestCallRecorder",
+	"pools" : [
+		 ],
+	"super" : "Object",
+	"type" : "normal" }

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/pitchC4.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/pitchC4.st
@@ -1,0 +1,6 @@
+accessing
+pitchC4
+	^ MNPitch new
+		octave: 4;
+		step: $c;
+		yourself

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testFlatSetHalfStepsA4.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testFlatSetHalfStepsA4.st
@@ -1,0 +1,9 @@
+tests
+testFlatSetHalfStepsA4
+	| pitch |
+	pitch := self pitchC4.
+	MNFlatTransposer new setHalfSteps: 57 of: pitch.
+	
+	self assert: pitch isNormal.
+	self assert: 4 equals: pitch octave.
+	self assert: $a equals: pitch step.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testFlatSetHalfStepsAb4.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testFlatSetHalfStepsAb4.st
@@ -1,0 +1,9 @@
+tests
+testFlatSetHalfStepsAb4
+	| pitch |
+	pitch := self pitchC4.
+	MNFlatTransposer new setHalfSteps: 56 of: pitch.
+	
+	self assert: pitch isFlat.
+	self assert: 4 equals: pitch octave.
+	self assert: $a equals: pitch step.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testHalfStepsOfC4.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testHalfStepsOfC4.st
@@ -1,0 +1,6 @@
+tests
+testHalfStepsOfC4
+	| pitch |
+	pitch := self pitchC4.
+	
+	self assert: 48 equals: (MNTransposer new halfStepsOf: pitch).

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testSharpSetHalfStepsA4.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testSharpSetHalfStepsA4.st
@@ -1,0 +1,9 @@
+tests
+testSharpSetHalfStepsA4
+	| pitch |
+	pitch := self pitchC4.
+	MNSharpTransposer new setHalfSteps: 57 of: pitch.
+	
+	self assert: pitch isNormal.
+	self assert: 4 equals: pitch octave.
+	self assert: $a equals: pitch step.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testSharpSetHalfStepsAs4.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testSharpSetHalfStepsAs4.st
@@ -1,0 +1,9 @@
+tests
+testSharpSetHalfStepsAs4
+	| pitch |
+	pitch := self pitchC4.
+	MNSharpTransposer new setHalfSteps: 58 of: pitch.
+	
+	self assert: pitch isSharp.
+	self assert: 4 equals: pitch octave.
+	self assert: $a equals: pitch step.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testTransposeC4Default.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testTransposeC4Default.st
@@ -1,0 +1,12 @@
+tests
+testTransposeC4Default
+	| pitch |
+	pitch := self pitchC4.
+	MNNote new addPitch: pitch; transpose: 3.
+	
+	self assert: 4 equals: pitch octave.
+	self assert: (MNPitch new
+		octave: 4;
+		step: $e;
+		alter: -1;
+		frequency) equals: pitch frequency.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testTransposeC4Flat.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testTransposeC4Flat.st
@@ -1,0 +1,9 @@
+tests
+testTransposeC4Flat
+	| pitch |
+	pitch := self pitchC4.
+	MNNote new addPitch: pitch; transposeFlat: 3.
+	
+	self assert: pitch isFlat.
+	self assert: 4 equals: pitch octave.
+	self assert: $e equals: pitch step.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testTransposeC4Sharp.st
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/instance/testTransposeC4Sharp.st
@@ -1,0 +1,9 @@
+tests
+testTransposeC4Sharp
+	| pitch |
+	pitch := self pitchC4.
+	MNNote new addPitch: pitch; transposeSharp: 3.
+	
+	self assert: pitch isSharp.
+	self assert: 4 equals: pitch octave.
+	self assert: $d equals: pitch step.

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/methodProperties.json
@@ -1,0 +1,13 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"pitchC4" : "mgjm 5/23/2019 00:12",
+		"testFlatSetHalfStepsA4" : "mgjm 5/23/2019 00:17",
+		"testFlatSetHalfStepsAb4" : "mgjm 5/23/2019 00:20",
+		"testHalfStepsOfC4" : "mgjm 5/23/2019 00:22",
+		"testSharpSetHalfStepsA4" : "mgjm 5/23/2019 00:17",
+		"testSharpSetHalfStepsAs4" : "mgjm 5/23/2019 00:18",
+		"testTransposeC4Default" : "mgjm 5/23/2019 00:21",
+		"testTransposeC4Flat" : "mgjm 5/23/2019 00:21",
+		"testTransposeC4Sharp" : "mgjm 5/23/2019 00:21" } }

--- a/packages/MusicNotation-Tests.package/MNTransposerTest.class/properties.json
+++ b/packages/MusicNotation-Tests.package/MNTransposerTest.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "MusicNotation-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "MNTransposerTest",
+	"pools" : [
+		 ],
+	"super" : "TestCase",
+	"type" : "normal" }


### PR DESCRIPTION
This adds basic functionality based on the visitor pattern.

Included Visitors:
- `MNSoundGenerator2`
- `MNFlatTansposer` and `MNSharpTransposer`

Example Code:
```squeak
proj := MNMusicXMLParser parseFileWithFileChooser.
proj transpose: 4.
proj asSound play.
```

---

This will close #1 (again, and as an alternative to #12) and #3 (as an alternative to #10).

## Progress
- [x] Base `MusicObject`
- [x] Base `MusicVisitor`
- [x] `SoundGenerator`
- [x] `Transposer`
- [x] Tests