### PR TITLE
Adds coverage testing

### DIFF
--- a/.smalltalk.ston
+++ b/.smalltalk.ston
@@ -6,5 +6,10 @@ SmalltalkCISpec {
       #directory : 'packages',
       #load : [ 'tests' ]
     }
-  ]
+  ],
+  #testing : {
+    #coverage : {
+      #packages : [ 'MusicNotation-.*' ]
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Music Notation [![Build Status](https://travis-ci.org/hpi-swa-teaching/MusicNotation.svg?branch=master)](https://travis-ci.org/hpi-swa-teaching/MusicNotation)
+# Music Notation [![Build Status](https://travis-ci.org/hpi-swa-teaching/MusicNotation.svg)](https://travis-ci.org/hpi-swa-teaching/MusicNotation) [![Coverage Status](https://coveralls.io/repos/github/hpi-swa-teaching/MusicNotation/badge.svg)](https://coveralls.io/github/hpi-swa-teaching/MusicNotation)
 
 Group 13


### PR DESCRIPTION
This will add coverage testing to the ci build and upload the result to coveralls.io.

Visit https://coveralls.io/github/hpi-swa-teaching/MusicNotation for the current coverage.