### PR TITLE
Fixes clear key method for measures

### DIFF
--- a/packages/MusicNotation-Core.package/MNCustomKey.class/instance/asFifths.st
+++ b/packages/MusicNotation-Core.package/MNCustomKey.class/instance/asFifths.st
@@ -2,4 +2,4 @@ converting
 asFifths
 	^ self accidentals
 		ifEmpty: 0
-		ifNotEmpty: nil
+		ifNotEmpty: [ nil ]

--- a/packages/MusicNotation-Core.package/MNCustomKey.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNCustomKey.class/methodProperties.json
@@ -5,7 +5,7 @@
 		"accidentals" : "mgjm 6/12/2019 03:44",
 		"accidentals:" : "mgjm 6/12/2019 03:44",
 		"addAccidental:alter:" : "mgjm 6/18/2019 23:49",
-		"asFifths" : "mgjm 6/12/2019 05:14",
+		"asFifths" : "mgjm 7/25/2019 14:15",
 		"equalTo:" : "mgjm 6/12/2019 06:06",
 		"hash" : "mgjm 6/18/2019 21:39",
 		"initialize" : "mgjm 6/12/2019 06:18",

--- a/packages/MusicNotation-Core.package/MNMeasure.class/instance/clearKey.st
+++ b/packages/MusicNotation-Core.package/MNMeasure.class/instance/clearKey.st
@@ -1,3 +1,3 @@
 accessing
 clearKey
-	self key: MNKey new.
+	self key: MNEmptyKey new.

--- a/packages/MusicNotation-Core.package/MNMeasure.class/methodProperties.json
+++ b/packages/MusicNotation-Core.package/MNMeasure.class/methodProperties.json
@@ -5,7 +5,7 @@
 	"instance" : {
 		"accept:" : "mgjm 5/15/2019 20:38",
 		"addNote:" : "mgjm 5/23/2019 21:54",
-		"clearKey" : "mgjm 6/12/2019 05:23",
+		"clearKey" : "mgjm 7/25/2019 13:59",
 		"clef" : "fb 6/10/2019 15:02",
 		"clef:" : "mgjm 6/12/2019 00:59",
 		"hash" : "mgjm 6/18/2019 21:45",

--- a/packages/MusicNotation-Tests.package/MNMeasureTest.class/instance/testMeasureFifths.st
+++ b/packages/MusicNotation-Tests.package/MNMeasureTest.class/instance/testMeasureFifths.st
@@ -1,0 +1,18 @@
+tests
+testMeasureFifths
+	| measure |
+	measure := MNMeasure new.
+	self assert: 0 equals: measure key asFifths.
+	
+	measure keyAccidentals: { $c -> 1 }.
+	self assert: (measure key asFifths = 0) not.
+	
+	measure keyAccidentals: {}.
+	self assert: 0 equals: measure key asFifths.
+	
+	-7 to: 7 do: [ :fifths |
+		measure keyFifths: fifths.
+		self assert: fifths equals: measure key asFifths ].
+	
+	measure clearKey.
+	self assert: 0 equals: measure key asFifths.

--- a/packages/MusicNotation-Tests.package/MNMeasureTest.class/methodProperties.json
+++ b/packages/MusicNotation-Tests.package/MNMeasureTest.class/methodProperties.json
@@ -4,5 +4,6 @@
 	"instance" : {
 		"testEmptyMeasure" : "aw 5/6/2019 23:22",
 		"testMeasureAccept" : "mgjm 5/22/2019 22:41",
+		"testMeasureFifths" : "mgjm 7/25/2019 14:13",
 		"testMeasureWithA4" : "aw 5/6/2019 23:25",
 		"testMeasureWithA4C5" : "aw 5/6/2019 23:27" } }


### PR DESCRIPTION
Fixes `MNMeasure >> #clearKey` and adds test case.

And fixes Bug in `MNCustomKey >> #asFifths`.